### PR TITLE
fix `un-get upgrade` command example in README

### DIFF
--- a/tmp/README.md.template
+++ b/tmp/README.md.template
@@ -48,7 +48,7 @@
    un-get install fish
 
    # Upgrade fish in the future
-   un-get update && un-get upgrade fish
+   un-get update && un-get upgrade
    ```
 
 ### Optional: Change the default shell to fish


### PR DESCRIPTION
`un-get upgrade` does not support individual packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade command documentation to reflect broader package upgrade operation without package-specific arguments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->